### PR TITLE
Add Google as an OAuth provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ Remove the credential information from storage.
 
 [Documentation](https://docs.gitlab.com/ee/api/oauth2.html)
 
+### Google (`google`)
+
+[Documentation](https://developers.google.com/identity/protocols/oauth2)
+
 ### Microsoft Azure AD (`microsoft_azure_ad`)
 
 [Documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cloud.google.com/go v0.34.0 h1:eOI3/cP2VTU6uZLDYAoic+eyzzB9YyGmJ7eIjl8rOPg=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/pkg/provider/basic.go
+++ b/pkg/provider/basic.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/oauth2/bitbucket"
 	"golang.org/x/oauth2/github"
 	"golang.org/x/oauth2/gitlab"
+	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/microsoft"
 	"golang.org/x/oauth2/slack"
 )
@@ -16,6 +17,7 @@ func init() {
 	GlobalRegistry.MustRegister("bitbucket", basicFactory(bitbucket.Endpoint))
 	GlobalRegistry.MustRegister("github", basicFactory(github.Endpoint))
 	GlobalRegistry.MustRegister("gitlab", basicFactory(gitlab.Endpoint))
+	GlobalRegistry.MustRegister("google", basicFactory(google.Endpoint))
 	GlobalRegistry.MustRegister("microsoft_azure_ad", azureADFactory)
 	GlobalRegistry.MustRegister("slack", basicFactory(slack.Endpoint))
 


### PR DESCRIPTION
This patch adds Google as an OAuth2 provider. We have been using this changeset at work and I was greenlit to upstream it. Thanks!