### PR TITLE
Expand characters allowed for creds path

### DIFF
--- a/pkg/backend/path_creds.go
+++ b/pkg/backend/path_creds.go
@@ -146,6 +146,12 @@ var credsFields = map[string]*framework.FieldSchema{
 	},
 }
 
+// Allow characters not special to urls or shells
+// Derived from framework.GenericNameWithAtRegex
+func credentialNameRegex(name string) string {
+	return fmt.Sprintf(`(?P<%s>\w(([\w.@~!_,:^-]+)?\w)?)`, name)
+}
+
 const credsHelpSynopsis = `
 Provides access tokens for authorized credentials.
 `
@@ -159,8 +165,7 @@ the access token will be available when reading the endpoint.
 
 func pathCreds(b *backend) *framework.Path {
 	return &framework.Path{
-		// Allow characters not special to urls or shells
-		Pattern: credsPathPrefix + strings.Replace(framework.GenericNameWithAtRegex("name"), "@", "@~!_,:^", 1) + `$`,
+		Pattern: credsPathPrefix + credentialNameRegex("name") + `$`,
 		Fields:  credsFields,
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{

--- a/pkg/backend/path_creds.go
+++ b/pkg/backend/path_creds.go
@@ -159,7 +159,8 @@ the access token will be available when reading the endpoint.
 
 func pathCreds(b *backend) *framework.Path {
 	return &framework.Path{
-		Pattern: credsPathPrefix + framework.GenericNameWithAtRegex("name") + `$`,
+		// Allow characters not special to urls or shells
+		Pattern: credsPathPrefix + strings.Replace(framework.GenericNameWithAtRegex("name"), "@", "@~!_,:^", 1) + `$`,
 		Fields:  credsFields,
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{


### PR DESCRIPTION
GenericNameWithAtRegex only allows 3 extra characters beyond alphanumeric: comma, period, and `@`.   That was very limiting for me because I needed to make up the path from two different pieces, one of which could contain all those characters, and I needed a way to delimit between the two pieces.  This PR extends the allowed characters to include additional ones that I could think of which were not special to either shells (when not at the beginning of a word) or urls.  I am planning to use colon as the delimiter but while I was at it I thought I might as well include others.  Also for completeness I began the regex with '^'.  