### PR TITLE
Add discovery_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ arbitrary OAuth 2 authorization code grant flow.
 
 | Name | Description | Default | Required |
 |------|-------------|---------|----------|
-| `auth_code_url` | The URL to submit the initial authorization code request to. | None | Yes |
-| `token_url` | The URL to use for exchanging temporary codes and refreshing access tokens. | None | Yes |
+| `discovery_url` | The URL at which to discover authorization code and token URLs. | None | Either this or the other two urls |
+| `auth_code_url` | The URL to submit the initial authorization code request to. | None | Either this or `discovery_url` |
+| `token_url` | The URL to use for exchanging temporary codes and refreshing access tokens. | None | Either this or `discovery_url` |
 | `auth_style` | How to authenticate to the token URL. If specified, must be one of `in_header` or `in_params`. | Automatically detect | No |

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,12 @@ module github.com/puppetlabs/vault-plugin-secrets-oauthapp
 go 1.12
 
 require (
+	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/hashicorp/go-hclog v0.8.0
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/hashicorp/vault/api v1.0.4
 	github.com/hashicorp/vault/sdk v0.1.14-0.20190909201848-e0fbf9b652e2
+	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7 // indirect
 	golang.org/x/net v0.0.0-20190916140828-c8589233b77d // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 h1:BUAU3CGlLvorLI26
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/coreos/go-oidc v2.2.1+incompatible h1:mh48q/BqXqgjVHpy2ZY7WnWAbenxRjsz9N1i1YxjHAk=
+github.com/coreos/go-oidc v2.2.1+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -89,6 +91,8 @@ github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
+github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 h1:J9b7z+QKAmPf4YLrFg6oQUotqHQeUNWwkvo7jZp1GLU=
+github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=

--- a/pkg/provider/basic.go
+++ b/pkg/provider/basic.go
@@ -166,7 +166,7 @@ func customFactory(vsn int, opts map[string]string) (Provider, error) {
 	if discoveryURL != "" {
 		provider, err := oidc.NewProvider(context.TODO(), discoveryURL)
 		if err != nil {
-			return nil, err
+			return nil, &OptionError{Option: "discovery_url", Message: "error making new provider: " + err.Error()}
 		}
 		authURL = provider.Endpoint().AuthURL
 		tokenURL = provider.Endpoint().TokenURL


### PR DESCRIPTION
I made a mistake on specifying a specific token_url and it was hard to track down.  A discovery_url is harder to mess up if the token issuer supports the .well-known/openid-configuration.  The discovery url is also the type of url used by vault-plugin-auth-jwt so it works better for those of us who are using both plugins.