### PR TITLE
Add minimum_seconds credential read option

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ Retrieve an authorization code URL for the given state.
 #### `GET` (`read`)
 
 Retrieve a current access token for the given credential.
+Reuses previous token if it is not yet expired or close to it.
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| `minimum_seconds` | Minimum seconds before access token expires | Integer | * | No |
+
+\* Defaults to underlying library default, which is 10 seconds unless
+  the token expiration time is set to zero.
 
 #### `PUT` (`write`)
 

--- a/pkg/backend/path_creds.go
+++ b/pkg/backend/path_creds.go
@@ -34,7 +34,7 @@ func (b *backend) credsReadOperation(ctx context.Context, req *logical.Request, 
 		return nil, err
 	} else if tok == nil {
 		return nil, nil
-	} else if !tokenOk2Reuse(tok, data) {
+	} else if !tokenValid(tok, data) {
 		return logical.ErrorResponse("token expired"), nil
 	}
 

--- a/pkg/backend/path_creds.go
+++ b/pkg/backend/path_creds.go
@@ -27,7 +27,7 @@ func credKey(name string) string {
 func (b *backend) credsReadOperation(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	key := credKey(data.Get("name").(string))
 
-	tok, err := b.getRefreshToken(ctx, req.Storage, key)
+	tok, err := b.getRefreshToken(ctx, req.Storage, key, data)
 	if err == ErrNotConfigured {
 		return logical.ErrorResponse("not configured"), nil
 	} else if err != nil {
@@ -128,10 +128,17 @@ func (b *backend) credsDeleteOperation(ctx context.Context, req *logical.Request
 }
 
 var credsFields = map[string]*framework.FieldSchema{
+	// fields for both read & write operations
 	"name": {
 		Type:        framework.TypeString,
 		Description: "Specifies the name of the credential.",
 	},
+	// fields for read operation
+	"minimum_seconds": {
+		Type:        framework.TypeInt,
+		Description: "Minimum remaining seconds to allow when reusing access token.",
+	},
+	// fields for write operation
 	"code": {
 		Type:        framework.TypeString,
 		Description: "Specifies the response code to exchange for a full token.",

--- a/pkg/backend/path_creds.go
+++ b/pkg/backend/path_creds.go
@@ -34,7 +34,7 @@ func (b *backend) credsReadOperation(ctx context.Context, req *logical.Request, 
 		return nil, err
 	} else if tok == nil {
 		return nil, nil
-	} else if !tok.Valid() {
+	} else if !tokenOk2Reuse(tok, data) {
 		return logical.ErrorResponse("token expired"), nil
 	}
 

--- a/pkg/backend/refresh.go
+++ b/pkg/backend/refresh.go
@@ -2,10 +2,28 @@ package backend
 
 import (
 	"context"
+	"time"
 
+	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 	"golang.org/x/oauth2"
 )
+
+func tokenOk2Reuse(tok *oauth2.Token, data *framework.FieldData) bool {
+	if !tok.Valid() {
+		return false
+	}
+	if data == nil {
+		return true
+	}
+	if minsecondsstr, ok := data.GetOk("minimum_seconds"); ok {
+		minseconds := minsecondsstr.(int)
+		if time.Until(tok.Expiry).Seconds() < float64(minseconds) {
+			return false
+		}
+	}
+	return true
+}
 
 func getToken(ctx context.Context, storage logical.Storage, key string) (*oauth2.Token, error) {
 	entry, err := storage.Get(ctx, key)
@@ -23,7 +41,7 @@ func getToken(ctx context.Context, storage logical.Storage, key string) (*oauth2
 	return tok, nil
 }
 
-func (b *backend) refreshToken(ctx context.Context, storage logical.Storage, key string) (*oauth2.Token, error) {
+func (b *backend) refreshToken(ctx context.Context, storage logical.Storage, key string, data *framework.FieldData) (*oauth2.Token, error) {
 	b.credMut.Lock()
 	defer b.credMut.Unlock()
 
@@ -34,9 +52,10 @@ func (b *backend) refreshToken(ctx context.Context, storage logical.Storage, key
 		return nil, err
 	} else if tok == nil {
 		return nil, nil
-	} else if tok.Valid() || tok.RefreshToken == "" {
+	} else if tokenOk2Reuse(tok, data) || tok.RefreshToken == "" {
 		return tok, nil
 	}
+	tok.AccessToken = ""
 
 	c, err := getConfig(ctx, storage)
 	if err != nil {
@@ -74,7 +93,7 @@ func (b *backend) refreshToken(ctx context.Context, storage logical.Storage, key
 	return refreshed, nil
 }
 
-func (b *backend) getRefreshToken(ctx context.Context, storage logical.Storage, key string) (*oauth2.Token, error) {
+func (b *backend) getRefreshToken(ctx context.Context, storage logical.Storage, key string, data *framework.FieldData) (*oauth2.Token, error) {
 	tok, err := getToken(ctx, storage, key)
 	if err != nil {
 		return nil, err
@@ -82,8 +101,8 @@ func (b *backend) getRefreshToken(ctx context.Context, storage logical.Storage, 
 		return nil, nil
 	}
 
-	if !tok.Valid() {
-		return b.refreshToken(ctx, storage, key)
+	if !tokenOk2Reuse(tok, data) {
+		return b.refreshToken(ctx, storage, key, data)
 	}
 
 	return tok, nil
@@ -94,7 +113,7 @@ func (b *backend) refreshPeriodic(ctx context.Context, req *logical.Request) err
 	logical.ScanView(ctx, view, func(path string) {
 		key := view.ExpandKey(path)
 
-		if _, err := b.getRefreshToken(ctx, req.Storage, key); err != nil {
+		if _, err := b.getRefreshToken(ctx, req.Storage, key, nil); err != nil {
 			b.logger.Error("unable to refresh token", "key", key, "error", err)
 		}
 	})

--- a/pkg/backend/refresh.go
+++ b/pkg/backend/refresh.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func tokenOk2Reuse(tok *oauth2.Token, data *framework.FieldData) bool {
+func tokenValid(tok *oauth2.Token, data *framework.FieldData) bool {
 	if !tok.Valid() {
 		return false
 	}
@@ -53,7 +53,7 @@ func (b *backend) refreshToken(ctx context.Context, storage logical.Storage, key
 		return nil, err
 	} else if tok == nil {
 		return nil, nil
-	} else if tokenOk2Reuse(tok, data) || tok.RefreshToken == "" {
+	} else if tokenValid(tok, data) || tok.RefreshToken == "" {
 		return tok, nil
 	}
 	tok.AccessToken = ""
@@ -102,7 +102,7 @@ func (b *backend) getRefreshToken(ctx context.Context, storage logical.Storage, 
 		return nil, nil
 	}
 
-	if !tokenOk2Reuse(tok, data) {
+	if !tokenValid(tok, data) {
 		return b.refreshToken(ctx, storage, key, data)
 	}
 

--- a/pkg/backend/refresh.go
+++ b/pkg/backend/refresh.go
@@ -18,7 +18,8 @@ func tokenOk2Reuse(tok *oauth2.Token, data *framework.FieldData) bool {
 	}
 	if minsecondsstr, ok := data.GetOk("minimum_seconds"); ok {
 		minseconds := minsecondsstr.(int)
-		if time.Until(tok.Expiry).Seconds() < float64(minseconds) {
+		zeroTime := time.Time{}
+		if tok.Expiry != zeroTime && time.Until(tok.Expiry).Seconds() < float64(minseconds) {
 			return false
 		}
 	}


### PR DESCRIPTION
This adds a minimum_seconds option to the credential read option.  If there are less than that many seconds remaining to the lifetime of a cached access token, it gets a new access token.