### PR TITLE
Add options to limit scopes or audience of access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,17 @@ Retrieve an authorization code URL for the given state.
 Retrieve a current access token for the given credential.
 Reuses previous token if it is not yet expired or close to it.
 
+If scopes or audience are requested, the current access token will be
+exchanged for another access token with more limited scopes or audience,
+and the more limited token returned.
+The more limited token is not saved for reuse; the less limited one is
+saved as usual.
+
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|----------|
-| `minimum_seconds` | Minimum seconds before access token expires | Integer | * | No |
+| `minimum_seconds` | Minimum seconds before access token expires. | Integer | * | No |
+| `scopes` | A list of explicit scopes to request. | List of String | None | No |
+| `audience` | An explicit audience to request. | String | None | No |
 
 \* Defaults to underlying library default, which is 10 seconds unless
   the token expiration time is set to zero.

--- a/pkg/backend/path_creds_test.go
+++ b/pkg/backend/path_creds_test.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"testing"
 	"time"
 
@@ -290,4 +291,114 @@ func TestRefreshFailureReturnsNotConfigured(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.EqualError(t, resp.Error(), "token expired")
+}
+
+func TestScopesAndAudienceRequests(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	client := provider.MockClient{
+		ID:     "hij",
+		Secret: "def",
+	}
+
+	storage := &logical.InmemStorage{}
+
+	b := New(Options{ProviderRegistry: provider.GlobalRegistry})
+	require.NoError(t, b.Setup(ctx, &logical.BackendConfig{}))
+
+	tp := provider.NewMockTokenProvider()
+	defer tp.Close()
+
+	// Write configuration.
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      configPath,
+		Storage:   storage,
+		Data: map[string]interface{}{
+			"client_id":     client.ID,
+			"client_secret": client.Secret,
+			"provider":      "custom",
+			"provider_options": map[string]string{
+				"auth_code_url" : "not-used",
+				"token_url" : tp.GetServerURL() + "/token",
+			},
+		},
+	}
+
+	resp, err := b.HandleRequest(ctx, req)
+	require.NoError(t, err)
+	require.False(t, resp != nil && resp.IsError(), "response has error: %+v", resp.Error())
+	require.Nil(t, resp)
+
+	// Write a valid credential.
+	req = &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      credsPathPrefix + `test`,
+		Storage:   storage,
+		Data: map[string]interface{}{
+			"refresh_token": "test",
+		},
+	}
+
+	resp, err = b.HandleRequest(ctx, req)
+	require.NoError(t, err)
+	require.False(t, resp != nil && resp.IsError(), "response has error: %+v", resp.Error())
+	require.Nil(t, resp)
+
+	req = &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      credsPathPrefix + `test`,
+		Storage:   storage,
+	}
+
+	resp, err = b.HandleRequest(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.False(t, resp.IsError(), "response has error: %+v", resp.Error())
+	require.NotNil(t, resp.Data["access_token"])
+	v, err := url.ParseQuery(resp.Data["access_token"].(string))
+	require.NoError(t, err)
+	default_scopes := v["scopes"]
+	require.NotNil(t, default_scopes)
+	default_audience := v["audience"]
+	require.NotNil(t, default_audience)
+
+	req = &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      credsPathPrefix + `test`,
+		Storage:   storage,
+		Data: map[string]interface{}{
+			"scopes": "scopea,scopec",
+		},
+	}
+
+	resp, err = b.HandleRequest(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.False(t, resp.IsError(), "response has error: %+v", resp.Error())
+	require.NotNil(t, resp.Data["access_token"])
+	v, err = url.ParseQuery(resp.Data["access_token"].(string))
+	require.NoError(t, err)
+	require.Equal(t, []string{"scopea scopec"}, v["scopes"])
+	require.Equal(t, default_audience, v["audience"])
+
+	req = &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      credsPathPrefix + `test`,
+		Storage:   storage,
+		Data: map[string]interface{}{
+			"audience": "specific",
+		},
+	}
+
+	resp, err = b.HandleRequest(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.False(t, resp.IsError(), "response has error: %+v", resp.Error())
+	require.NotNil(t, resp.Data["access_token"])
+	v, err = url.ParseQuery(resp.Data["access_token"].(string))
+	require.NoError(t, err)
+	require.Equal(t, default_scopes, v["scopes"])
+	require.Equal(t, []string{"specific"}, v["audience"])
 }

--- a/pkg/provider/mock.go
+++ b/pkg/provider/mock.go
@@ -6,6 +6,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -308,3 +310,70 @@ func MockFactory(opts ...MockOption) FactoryFunc {
 
 	return m.factory
 }
+
+// tokenProvider is a local server that mocks RFC8693 token exchange
+type tokenProvider struct {
+	server       *httptest.Server
+}
+
+func NewMockTokenProvider() *tokenProvider {
+	tp := new(tokenProvider)
+	tp.server = httptest.NewServer(tp)
+
+	return tp
+}
+
+func (tp *tokenProvider) GetServerURL() string {
+	return tp.server.URL
+}
+
+func (tp *tokenProvider) Close() {
+	tp.server.Close()
+}
+
+func (tp *tokenProvider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	errmsg := ""
+
+	switch r.URL.Path {
+	case "/token":
+		grant_type := r.FormValue("grant_type")
+		tok := url.Values{}
+		if grant_type != "urn:ietf:params:oauth:grant-type:token-exchange" {
+			tok["scopes"] = []string{"scopea scopeb scopec"}
+			tok["audience"] = []string{"any"}
+		} else {
+			subject_token := r.FormValue("subject_token")
+			if subject_token == "" {
+				errmsg = "no subject_token"
+				break
+			}
+			params, err := url.ParseQuery(subject_token)
+			if err != nil {
+				errmsg = "could not parse subject_token"
+				break
+			}
+			scopes := r.FormValue("scope")
+			if scopes != "" {
+				tok["scopes"] = []string{scopes}
+			} else {
+				tok["scopes"] = params["scopes"]
+			}
+			audience := r.FormValue("audience")
+			if audience != "" {
+				tok["audience"] = []string{audience}
+			} else {
+				tok["audience"] = params["audience"]
+			}
+		}
+
+		// simple manual json encoding
+		w.Write([]byte(`{"access_token": "` + tok.Encode() + `"}`))
+		return
+	default:
+		errmsg = fmt.Sprintf("unexpected path: %q", r.URL.Path)
+	}
+	w.Write([]byte(`{"error": "` + errmsg + `"}`))
+}
+


### PR DESCRIPTION
This adds "scopes" and "audience" options to the creds read.  It works by doing an RFC8693 token exchange using the regular access token.

Since this touches some of the same code as pr #16, it includes those changes and should be merged after that one.  To see just the changes for this pr, see [my pr #1](https://github.com/DrDaveD/vault-plugin-secrets-oauthapp/pull/1).

