### PR TITLE
Support for client credentials grant type

### DIFF
--- a/pkg/backend/errors.go
+++ b/pkg/backend/errors.go
@@ -3,5 +3,6 @@ package backend
 import "errors"
 
 var (
-	ErrNotConfigured = errors.New("not configured")
+	ErrNotConfigured      = errors.New("not configured")
+	ErrInvalidCredentials = errors.New("invalid client credentials")
 )

--- a/pkg/backend/path_config.go
+++ b/pkg/backend/path_config.go
@@ -126,6 +126,10 @@ func (b *backend) configAuthCodeURLUpdateOperation(ctx context.Context, req *log
 		return nil, err
 	}
 
+	if !p.IsAuthorizationRequired() {
+		return logical.ErrorResponse("this provider does not support generating authorization URL"), nil
+	}
+
 	state, ok := data.GetOk("state")
 	if !ok {
 		return logical.ErrorResponse("missing state"), nil

--- a/pkg/provider/basic_test.go
+++ b/pkg/provider/basic_test.go
@@ -2,10 +2,13 @@ package provider
 
 import (
 	"context"
+	"encoding/base64"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -31,6 +34,16 @@ var basicTest = &basic{
 		TokenURL:  "http://localhost/token",
 		AuthStyle: oauth2.AuthStyleInParams,
 	},
+}
+
+var basicTestNoAuth = &basic{
+	vsn: 1,
+	endpoint: oauth2.Endpoint{
+		AuthURL:   "http://localhost/authorize",
+		TokenURL:  "http://localhost/token",
+		AuthStyle: oauth2.AuthStyleInParams,
+	},
+	isAuthorizationRequired: false,
 }
 
 func TestBasicAuthCodeURLConfig(t *testing.T) {
@@ -114,5 +127,75 @@ func TestBasicExchangeConfig(t *testing.T) {
 
 	// Our refreshed response is good for an hour.
 	require.Equal(t, "ijkl", token.AccessToken)
+	require.True(t, token.Valid())
+}
+
+func TestTokenExchangeConfig(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	i := 1
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			b, err := ioutil.ReadAll(r.Body)
+			require.NoError(t, err)
+
+			authHeader := r.Header.Get("Authorization")
+			require.True(t, strings.HasPrefix(authHeader, "Basic "))
+
+			auth, err := base64.StdEncoding.DecodeString(authHeader[6:])
+			require.NoError(t, err)
+			assert.Equal(t, "foo:bar", string(auth))
+
+			data, err := url.ParseQuery(string(b))
+			require.NoError(t, err)
+
+			switch data.Get("grant_type") {
+			case "client_credentials":
+				assert.Equal(t, "client_credentials", data.Get("grant_type"))
+				assert.Equal(t, "a b c", data.Get("scope"))
+
+				expiresIn := 5
+				if i > 1 {
+					expiresIn = 3600
+				}
+
+				w.Write([]byte(fmt.Sprintf(`access_token=abcd%d&refresh_token=efgh&token_type=bearer&expires_in=%d`, i, expiresIn)))
+				i++
+			default:
+				assert.Fail(t, "unexpected `grant_type` value: %q", data.Get("grant_type"))
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	c := &http.Client{Transport: &MockRoundTripper{Handler: h}}
+
+	require.False(t, basicTestNoAuth.IsAuthorizationRequired())
+	cb, err := basicTestNoAuth.NewTokenConfigBuilder("foo", "bar")
+	require.NoError(t, err)
+
+	conf := cb.WithHTTPClient(c).
+		WithScopes("a b c").
+		Build()
+
+	token, err := conf.Token(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, token)
+	require.Equal(t, "abcd1", token.AccessToken)
+	require.Equal(t, "Bearer", token.Type())
+	require.Equal(t, "efgh", token.RefreshToken)
+	require.NotEmpty(t, token.Expiry)
+
+	// This token is already invalid, so let's try to refresh it.
+	require.False(t, token.Valid())
+
+	token, err = conf.TokenSource(ctx).Token()
+	require.NoError(t, err)
+	require.NotNil(t, token)
+
+	// Our refreshed response is good for an hour.
+	require.Equal(t, "abcd2", token.AccessToken)
 	require.True(t, token.Valid())
 }

--- a/pkg/provider/errors.go
+++ b/pkg/provider/errors.go
@@ -9,6 +9,7 @@ var (
 	ErrNoSuchProvider        = errors.New("provider: no provider with the given name")
 	ErrNoProviderWithVersion = errors.New("provider: version not supported")
 	ErrNoOptions             = errors.New("provider: options provided but none accepted")
+	ErrAuthRequired          = errors.New("provider: authorization is required")
 )
 
 type OptionError struct {

--- a/pkg/provider/mock.go
+++ b/pkg/provider/mock.go
@@ -221,6 +221,14 @@ func (mp *mockProvider) NewExchangeConfigBuilder(clientID, clientSecret string) 
 	}
 }
 
+func (mp *mockProvider) NewTokenConfigBuilder(clientID, clientSecret string) (TokenConfigBuilder, error) {
+	return nil, ErrAuthRequired
+}
+
+func (mp *mockProvider) IsAuthorizationRequired() bool {
+	return true
+}
+
 type mock struct {
 	vsn          int
 	expectedOpts map[string]string

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -44,6 +44,25 @@ type ExchangeConfigBuilder interface {
 	Build() ExchangeConfig
 }
 
+// TokenConfig is the component of *oauth2/clientcredentials.Config required
+// for retrieving a token via 2-legged OAuth
+type TokenConfig interface {
+	Token(ctx context.Context) (*oauth2.Token, error)
+	TokenSource(ctx context.Context) oauth2.TokenSource
+}
+
+// TokenConfigBuilder creates TokenConfigs.
+type TokenConfigBuilder interface {
+	// WithHTTPClient uses the given HTTP client to perform the exchange.
+	WithHTTPClient(client *http.Client) TokenConfigBuilder
+
+	// WithScopes sets the scopes for the config.
+	WithScopes(scopes ...string) TokenConfigBuilder
+
+	// Build creates an TokenConfig from the current configuration.
+	Build() TokenConfig
+}
+
 // Provider represents an integration with a particular OAuth provider using the
 // authorization code grant.
 type Provider interface {
@@ -57,6 +76,13 @@ type Provider interface {
 
 	// NewExchangeConfigBuilder creates a new config builder for token exchange.
 	NewExchangeConfigBuilder(clientID, clientSecret string) ExchangeConfigBuilder
+
+	// NewTokenConfigBuilder creates a new config builder for 2-legged token exchange.
+	NewTokenConfigBuilder(clientID, clientSecret string) (TokenConfigBuilder, error)
+
+	// IsAuthorizationRequired returns true if authorization is required (i.e. 3-legged OAuth)
+	// or returns false if it's not required (i.e. 2-legged OAuth)
+	IsAuthorizationRequired() bool
 }
 
 var GlobalRegistry = NewRegistry()


### PR DESCRIPTION
This PR adds support for a client credentials grant type, also known as 2-legged OAuth.

The Client Credentials grant type is used by clients to obtain an access token outside of the context of a user.
This is typically used by clients to access resources about themselves rather than to access a user's resources.

Main changes:

- Added a new provider `custom_client_credentials`
- Read to `creds/user` requests a new token if not already available
- Periodic refresh does not refresh the token since there's no refresh token with a client credentials grant type

Any feedback is highly appreciated.