### PR TITLE
Allow slash in credential names

### DIFF
--- a/pkg/backend/path.go
+++ b/pkg/backend/path.go
@@ -7,10 +7,11 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-// nameRegex allows most printable ASCII characters in path names that are not
-// slashes.
-func nameRegex(name string) string {
-	return fmt.Sprintf(`(?P<%s>\w(([\w.@~!_,:^-]+)?\w)?)`, name)
+// nameRegex allows characters not special to urls or shells,
+//  plus any additional characters passed in as extras
+// Derived from framework.GenericNameWithAtRegex
+func nameRegex(name, extras string) string {
+	return fmt.Sprintf(`(?P<%s>\w(([\w.@~!_,`+extras+`:^-]+)?\w)?)`, name)
 }
 
 func pathsSpecial() *logical.Paths {

--- a/pkg/backend/path_creds.go
+++ b/pkg/backend/path_creds.go
@@ -376,7 +376,7 @@ the access token will be available when reading the endpoint.
 
 func pathCreds(b *backend) *framework.Path {
 	return &framework.Path{
-		Pattern: CredsPathPrefix + nameRegex("name") + `$`,
+		Pattern: CredsPathPrefix + nameRegex("name", "/") + `$`,
 		Fields:  credsFields,
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{

--- a/pkg/backend/path_self.go
+++ b/pkg/backend/path_self.go
@@ -144,7 +144,7 @@ needed.
 
 func pathSelf(b *backend) *framework.Path {
 	return &framework.Path{
-		Pattern: SelfPathPrefix + nameRegex("name") + `$`,
+		Pattern: SelfPathPrefix + nameRegex("name", "") + `$`,
 		Fields:  selfFields,
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{
@@ -196,7 +196,7 @@ the token endpoint of a client credentials flow.
 
 func pathSelfConfig(b *backend) *framework.Path {
 	return &framework.Path{
-		Pattern: SelfPathPrefix + nameRegex("name") + `/config$`,
+		Pattern: SelfPathPrefix + nameRegex("name", "") + `/config$`,
 		Fields:  selfConfigFields,
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{


### PR DESCRIPTION
This allows slash to be in credential names.

As I first mentioned in [pr #18](https://github.com/puppetlabs/vault-plugin-secrets-oauthapp/pull/18#issuecomment-749212781):

> > After the initial OIDC authentication we plan to renew our vault credentials weekly with kerberos. In addition to the user's regular kerberos credentials, we have the ability to create "robot" kerberos credentials of the form <user>/cron/<machinename> which are to be used for automated operations via cron. We can translate a credential of that form to a subpath in vault under creds using a vault policy we apply to the auth-kerberos plugin. 

@impl replied:
> I am OK with that change to the acceptable path tokens as long as the intention is to escape the / -- e.g., would need to be creds/foo%2fbar and not creds/foo/bar.

I would like to do that but the problem is that there are no controls in the kerberos plugin to edit the kerberos credential name when creating a vault policy file.  As you pointed out later in the same comment, I can insert `{{ identity.entity.name }}` into the policy anywhere I want, but there's no provision for editing it to change slashes into %2f.  I understand that allowing slashes in the credential name makes things more complicated to look for the "/tokens/" separator being discussed in that PR, but I think it can still be made to work OK.  There is a risk that the separator may be accidentally included as part of the credential name, so maybe the separator would need to include a special character not allowed in a credential name.

Since with this PR both "." and "/" would be allowed in a credential name, I tested what happens with "/../".  I found out that vault canonicalizes that and removes such constructs (going up a level in the path like a Unix filesystem) so it would never reach the plugin and we don't need to worry about that at least.