### PR TITLE
Allow the nonce to be empty

### DIFF
--- a/pkg/provider/oidc.go
+++ b/pkg/provider/oidc.go
@@ -47,8 +47,12 @@ func (c *oidcExchangeConfig) verifyUpdateToken(ctx context.Context, t *Token) er
 		return fmt.Errorf("provider: oidc: verification error: %+v", err)
 	}
 
-	if subtle.ConstantTimeEq(int32(len(idToken.Nonce)), int32(len(c.nonce))) == 0 ||
-		subtle.ConstantTimeCompare([]byte(idToken.Nonce), []byte(c.nonce)) == 0 {
+	// If nonce is configured, make sure it matches the nonce in
+	// the ID token.  It is not configured when refresh_token is
+	// sent in from an external source.
+	if len(c.nonce) > 0 &&
+		(subtle.ConstantTimeEq(int32(len(idToken.Nonce)), int32(len(c.nonce))) == 0 ||
+			subtle.ConstantTimeCompare([]byte(idToken.Nonce), []byte(c.nonce)) == 0) {
 		return ErrOIDCNonceMismatch
 	}
 


### PR DESCRIPTION
I ran into a nonce mismatch error with the new oidc provider and when writing the refresh_token through the API.  This prevents the error.