### PR TITLE
Expose errors from underlying providers more helpfully

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,6 +6,11 @@ linters-settings:
     - opinionated
     - performance
     - style
+    disabled-checks:
+    - ifElseChain
+    settings:
+      hugeParam:
+        sizeThreshold: 512
   gocyclo:
     min-complexity: 20
   nolintlint:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+* Errors caused by configuration problems in the OIDC provider are now correctly
+  propagated to the HTTP response with a 400 status code.
+
 ### Changed
 
 * The `testutil` package now uses a `*provider.Token` instead of a

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/hashicorp/vault/api v1.0.4
 	github.com/hashicorp/vault/sdk v0.1.14-0.20190909201848-e0fbf9b652e2
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
+	github.com/puppetlabs/leg/errmap v0.0.0-20210114071727-81c4a243ca52
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	google.golang.org/appengine v1.6.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/vault/api v1.0.4
 	github.com/hashicorp/vault/sdk v0.1.14-0.20190909201848-e0fbf9b652e2
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
-	github.com/puppetlabs/leg/errmap v0.0.0-20210114071727-81c4a243ca52
+	github.com/puppetlabs/leg/errmap v0.1.0
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	google.golang.org/appengine v1.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -370,6 +370,10 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/puppetlabs/leg/datastructure v0.1.0 h1:0703wQJ71etqsPOr+vfiTBHkq0+tVVT0kH7iluwH7GU=
+github.com/puppetlabs/leg/datastructure v0.1.0/go.mod h1:4Kwk/83hkiR1smN1gRsi0LJDgVDbD672JpWjRPBVka8=
+github.com/puppetlabs/leg/errmap v0.0.0-20210114071727-81c4a243ca52 h1:a/J80axFyrKBZR6VpXbks9gN9HMzKUtJl0cn2oCQjE4=
+github.com/puppetlabs/leg/errmap v0.0.0-20210114071727-81c4a243ca52/go.mod h1:8oVNaeaaprDjbMYWHj5lLHsD1nsnKZbv0Jw+SjoJ6hY=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/quasilyte/go-ruleguard v0.2.0 h1:UOVMyH2EKkxIfzrULvA9n/tO+HtEhqD9mrLSWMr5FwU=
 github.com/quasilyte/go-ruleguard v0.2.0/go.mod h1:2RT/tf0Ce0UDj5y243iWKosQogJd8+1G3Rs2fxmlYnw=

--- a/go.sum
+++ b/go.sum
@@ -372,8 +372,8 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/puppetlabs/leg/datastructure v0.1.0 h1:0703wQJ71etqsPOr+vfiTBHkq0+tVVT0kH7iluwH7GU=
 github.com/puppetlabs/leg/datastructure v0.1.0/go.mod h1:4Kwk/83hkiR1smN1gRsi0LJDgVDbD672JpWjRPBVka8=
-github.com/puppetlabs/leg/errmap v0.0.0-20210114071727-81c4a243ca52 h1:a/J80axFyrKBZR6VpXbks9gN9HMzKUtJl0cn2oCQjE4=
-github.com/puppetlabs/leg/errmap v0.0.0-20210114071727-81c4a243ca52/go.mod h1:8oVNaeaaprDjbMYWHj5lLHsD1nsnKZbv0Jw+SjoJ6hY=
+github.com/puppetlabs/leg/errmap v0.1.0 h1:1oH50d/sch1kB5JuIRrLf0hg9gSr5pfAmTUc6o8CtZQ=
+github.com/puppetlabs/leg/errmap v0.1.0/go.mod h1:8oVNaeaaprDjbMYWHj5lLHsD1nsnKZbv0Jw+SjoJ6hY=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/quasilyte/go-ruleguard v0.2.0 h1:UOVMyH2EKkxIfzrULvA9n/tO+HtEhqD9mrLSWMr5FwU=
 github.com/quasilyte/go-ruleguard v0.2.0/go.mod h1:2RT/tf0Ce0UDj5y243iWKosQogJd8+1G3Rs2fxmlYnw=

--- a/pkg/backend/path_creds_test.go
+++ b/pkg/backend/path_creds_test.go
@@ -135,7 +135,7 @@ func TestInvalidCredentialExchange(t *testing.T) {
 	resp, err = b.HandleRequest(ctx, req)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
-	require.EqualError(t, resp.Error(), "invalid code")
+	require.EqualError(t, resp.Error(), "exchange failed: oauth2: cannot fetch token: Forbidden\nResponse: ")
 }
 
 func TestRefreshableCredentialExchange(t *testing.T) {

--- a/pkg/provider/basic.go
+++ b/pkg/provider/basic.go
@@ -143,7 +143,7 @@ func CustomFactory(ctx context.Context, vsn int, opts map[string]string) (Provid
 		if discoveryURL != "" {
 			provider, err := gooidc.NewProvider(ctx, discoveryURL)
 			if err != nil {
-				return nil, &OptionError{Option: "discovery_url", Message: "error making new provider: " + err.Error()}
+				return nil, &OptionError{Option: "discovery_url", Message: "error making new provider", Cause: err}
 			}
 
 			opts["auth_code_url"] = provider.Endpoint().AuthURL

--- a/pkg/provider/errors.go
+++ b/pkg/provider/errors.go
@@ -6,16 +6,25 @@ import (
 )
 
 var (
-	ErrNoSuchProvider        = errors.New("provider: no provider with the given name")
-	ErrNoProviderWithVersion = errors.New("provider: version not supported")
-	ErrNoOptions             = errors.New("provider: options provided but none accepted")
+	ErrNoSuchProvider        = errors.New("no provider with the given name")
+	ErrNoProviderWithVersion = errors.New("version not supported")
+	ErrNoOptions             = errors.New("options provided but none accepted")
 )
 
 type OptionError struct {
 	Option  string
 	Message string
+	Cause   error
 }
 
 func (oe *OptionError) Error() string {
-	return fmt.Sprintf("provider: option %q: %s", oe.Option, oe.Message)
+	msg := fmt.Sprintf("option %q: %s", oe.Option, oe.Message)
+	if oe.Cause != nil {
+		msg += ": " + oe.Cause.Error()
+	}
+	return msg
+}
+
+func (oe *OptionError) Unwrap() error {
+	return oe.Cause
 }

--- a/pkg/testutil/mock.go
+++ b/pkg/testutil/mock.go
@@ -114,15 +114,15 @@ func IncrementMockExchange(prefix string) MockExchangeFunc {
 	}
 }
 
-func ErrorMockExchange(_ string) (*oauth2.Token, error) {
-	return nil, &oauth2.RetrieveError{}
+func ErrorMockExchange(_ string) (*provider.Token, error) {
+	return nil, &oauth2.RetrieveError{Response: &http.Response{Status: http.StatusText(http.StatusForbidden)}}
 }
 
 func RestrictMockExchange(m map[string]MockExchangeFunc) MockExchangeFunc {
 	return func(token string) (*provider.Token, error) {
 		fn, found := m[token]
 		if !found {
-			return nil, &oauth2.RetrieveError{}
+			fn = ErrorMockExchange
 		}
 
 		return fn(token)
@@ -136,7 +136,7 @@ type mockExchangeConfig struct {
 
 func (c *mockExchangeConfig) Exchange(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*provider.Token, error) {
 	if c.fn == nil {
-		return nil, &oauth2.RetrieveError{}
+		return nil, &oauth2.RetrieveError{Response: &http.Response{Status: http.StatusText(http.StatusInternalServerError)}}
 	}
 
 	tok, err := c.fn(code)


### PR DESCRIPTION
Dependencies:
* [x] puppetlabs/leg#6

This change surfaces most errors from the provider package as "user" errors that get a proper response generated for them instead of a 500 error.

In particular, @DrDaveD will be happy to know that I've had a change of heart on #14, for two reasons:
* I looked at the code for the JWT auth plugin and it's at least as verbose, if not more verbose, than the changes I'm proposing here. So there's some precedent to this.
* It turns out that when you return an `err` in your plugin it just gets written back as a 500 with the complete error text, so all of these errors that were user-facing but not marked as such (i.e., those that I didn't want propagated) were doing exactly that. I quote myself here: "a lot of consumers of these types of APIs just propagate error messages back upstream." Turns out those consumers is me.

By the way, the problem with returning 500s is that the Vault API client (the Go one, at least) just blindly retries those requests _and_ masks the error that was originally returned, making debugging effectively impossible, as we learned this week.

Here's what an error response looks like now:

```
Error writing data to oauth/auth0/creds/test: Error making API request.

URL: PUT http://localhost:8200/v1/oauth/auth0/creds/test
Code: 400. Errors:

* exchange failed: oauth2: cannot fetch token: 403 Forbidden
Response: {"error":"invalid_grant","error_description":"Invalid authorization code"}
```