### PR TITLE
Make auth code URL optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ tokens.
 
 #### `PUT` (`write`)
 
-Retrieve an authorization code URL for the given state.
+Retrieve an authorization code URL for the given state. Some providers may not
+provide the plugin with information about this URL, in which case accessing this
+endpoint will return an error.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|----------|
@@ -284,6 +286,6 @@ arbitrary OAuth 2 authorization code grant flow.
 
 | Name | Description | Default | Required |
 |------|-------------|---------|----------|
-| `auth_code_url` | The URL to submit the initial authorization code request to. | None | Yes |
+| `auth_code_url` | The URL to submit the initial authorization code request to. | None | No |
 | `token_url` | The URL to use for exchanging temporary codes and refreshing access tokens. | None | Yes |
 | `auth_style` | How to authenticate to the token URL. If specified, must be one of `in_header` or `in_params`. | Automatically detect | No |

--- a/pkg/backend/path_config.go
+++ b/pkg/backend/path_config.go
@@ -104,13 +104,16 @@ func (b *backend) configAuthCodeURLUpdateOperation(ctx context.Context, req *log
 		return logical.ErrorResponse("missing state"), nil
 	}
 
-	url := c.Provider.Public(c.Config.ClientID).AuthCodeURL(
+	url, ok := c.Provider.Public(c.Config.ClientID).AuthCodeURL(
 		state.(string),
 		provider.WithRedirectURL(data.Get("redirect_url").(string)),
 		provider.WithScopes(data.Get("scopes").([]string)),
 		provider.WithURLParams(data.Get("auth_url_params").(map[string]string)),
 		provider.WithURLParams(c.Config.AuthURLParams),
 	)
+	if !ok {
+		return logical.ErrorResponse("authorization code URL not available"), nil
+	}
 
 	resp := &logical.Response{
 		Data: map[string]interface{}{

--- a/pkg/provider/basic.go
+++ b/pkg/provider/basic.go
@@ -29,7 +29,11 @@ type basicOperations struct {
 	base *oauth2.Config
 }
 
-func (bo *basicOperations) AuthCodeURL(state string, opts ...AuthCodeURLOption) string {
+func (bo *basicOperations) AuthCodeURL(state string, opts ...AuthCodeURLOption) (string, bool) {
+	if bo.base.Endpoint.AuthURL == "" {
+		return "", false
+	}
+
 	o := &AuthCodeURLOptions{}
 	o.ApplyOptions(opts)
 
@@ -38,7 +42,7 @@ func (bo *basicOperations) AuthCodeURL(state string, opts ...AuthCodeURLOption) 
 	cfg.Scopes = o.Scopes
 	cfg.RedirectURL = o.RedirectURL
 
-	return cfg.AuthCodeURL(state, o.AuthCodeOptions...)
+	return cfg.AuthCodeURL(state, o.AuthCodeOptions...), true
 }
 
 func (bo *basicOperations) AuthCodeExchange(ctx context.Context, code string, opts ...AuthCodeExchangeOption) (*Token, error) {
@@ -173,10 +177,6 @@ func CustomFactory(ctx context.Context, vsn int, opts map[string]string) (Provid
 		}
 	default:
 		return nil, ErrNoProviderWithVersion
-	}
-
-	if opts["auth_code_url"] == "" {
-		return nil, &OptionError{Option: "auth_code_url", Message: "authorization code URL is required"}
 	}
 
 	if opts["token_url"] == "" {

--- a/pkg/provider/basic_test.go
+++ b/pkg/provider/basic_test.go
@@ -32,12 +32,15 @@ func TestBasicPublic(t *testing.T) {
 
 	ops := basicTest.Public("foo")
 
-	u, err := url.Parse(ops.AuthCodeURL(
+	authCodeURL, ok := ops.AuthCodeURL(
 		"state",
 		provider.WithRedirectURL("http://example.com/redirect"),
 		provider.WithScopes{"a", "b", "c"},
 		provider.WithURLParams{"baz": "quux"},
-	))
+	)
+	require.True(t, ok)
+
+	u, err := url.Parse(authCodeURL)
 	require.NoError(t, err)
 
 	assert.Equal(t, "http", u.Scheme)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -36,7 +36,7 @@ func (o *AuthCodeURLOptions) ApplyOptions(opts []AuthCodeURLOption) {
 // PublicOperations defines the operations for a client that only require
 // knowledge of the client ID.
 type PublicOperations interface {
-	AuthCodeURL(state string, opts ...AuthCodeURLOption) string
+	AuthCodeURL(state string, opts ...AuthCodeURLOption) (string, bool)
 }
 
 // AuthCodeExchangeOptions are options for the AuthCodeExchange operation.

--- a/pkg/testutil/mock.go
+++ b/pkg/testutil/mock.go
@@ -169,7 +169,7 @@ type mockOperations struct {
 	clientCredentialsFn MockClientCredentialsFunc
 }
 
-func (mo *mockOperations) AuthCodeURL(state string, opts ...provider.AuthCodeURLOption) string {
+func (mo *mockOperations) AuthCodeURL(state string, opts ...provider.AuthCodeURLOption) (string, bool) {
 	o := &provider.AuthCodeURLOptions{}
 	o.ApplyOptions(opts)
 
@@ -178,7 +178,7 @@ func (mo *mockOperations) AuthCodeURL(state string, opts ...provider.AuthCodeURL
 		Endpoint:    MockEndpoint,
 		Scopes:      o.Scopes,
 		RedirectURL: o.RedirectURL,
-	}).AuthCodeURL(state, o.AuthCodeOptions...)
+	}).AuthCodeURL(state, o.AuthCodeOptions...), true
 }
 
 func (mo *mockOperations) AuthCodeExchange(ctx context.Context, code string, opts ...provider.AuthCodeExchangeOption) (*provider.Token, error) {


### PR DESCRIPTION
This change makes it optional to provide the auth code URL for a provider. This allows totally external auth (plugin has no knowledge of how users get the code) as well as machine-to-machine only auth that doesn't use 3-legged auth at all.