### PR TITLE
Fix minimum_seconds option

### DIFF
--- a/pkg/backend/path_creds_test.go
+++ b/pkg/backend/path_creds_test.go
@@ -298,7 +298,7 @@ func TestRefreshFailureReturnsNotConfigured(t *testing.T) {
 	resp, err = b.HandleRequest(ctx, req)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
-	require.EqualError(t, resp.Error(), "token expired")
+	require.EqualError(t, resp.Error(), "token pending issuance")
 }
 
 func TestDeviceCodeAuthAndExchange(t *testing.T) {

--- a/pkg/backend/token_authcode.go
+++ b/pkg/backend/token_authcode.go
@@ -91,6 +91,9 @@ func (b *backend) refreshCredToken(ctx context.Context, storage logical.Storage,
 		}
 
 		// Refresh.
+		// First clear out old AccessToken so oauth2 will not
+		//   re-use tokens we think are expired
+		candidate.AccessToken = ""
 		refreshed, err := c.Provider.Private(c.Config.ClientID, c.Config.ClientSecret).RefreshToken(ctx, candidate.Token)
 		if err != nil {
 			msg := errmap.Wrap(errmark.MarkShort(err), "refresh failed").Error()


### PR DESCRIPTION
Version v1.10.0 broke the minimum_seconds option by no longer clearing the access token before doing a refresh.  The oauth2 library by default reuses any access tokens that have more than 10 seconds remaining on them.