### PR TITLE
Add refresh_interval config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,12 +151,12 @@ $ vault write oauth2/bitbucket/self/my-machine-auth/config \
 Success! Data written to: oauth2/bitbucket/self/my-machine-auth/config
 ```
 
-### Automatic refreshing
+### Automatic refresh checking
 
-By default tokens are automatically refreshed every 60 seconds.  You can
-change that interval by setting the refresh_interval config option to
-another number of seconds.  If set to zero, tokens will be refreshed
-only on demand.
+By default tokens are automatically checked for refresh every 60
+seconds.  You can change that interval by setting the
+`tune_refresh_check_interval_seconds` config option to another number of
+seconds.  If set to zero, tokens will be refreshed only on demand.
 
 ## Tips
 
@@ -190,7 +190,13 @@ configuration, so you must specify all required fields, even when updating.
 | `auth_url_params` | A map of additional query string parameters to provide to the authorization code URL. | Map of String🠦String | None | No |
 | `provider` | The name of the provider to use. See [the list of providers](#providers). | String | None | Yes |
 | `provider_options` | Options to configure the specified provider. | Map of String🠦String | None | No |
-| `refresh_interval` | Number of seconds between automated refreshing. | Integer | 60 | No |
+
+There is also an additional configuration option that may be set for
+fine tuning.
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `tune_refresh_check_interval_seconds` | Number of seconds between checking tokens for refresh. | Integer | 60 |
 
 #### `DELETE` (`delete`)
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,13 @@ $ vault write oauth2/bitbucket/self/my-machine-auth/config \
 Success! Data written to: oauth2/bitbucket/self/my-machine-auth/config
 ```
 
+### Automatic refreshing
+
+By default tokens are automatically refreshed every 60 seconds.  You can
+change that interval by setting the refresh_interval config option to
+another number of seconds.  If set to zero, tokens will be refreshed
+only on demand.
+
 ## Tips
 
 For some operations, you may find that you need to provide a map of data for a
@@ -183,6 +190,7 @@ configuration, so you must specify all required fields, even when updating.
 | `auth_url_params` | A map of additional query string parameters to provide to the authorization code URL. | Map of String🠦String | None | No |
 | `provider` | The name of the provider to use. See [the list of providers](#providers). | String | None | Yes |
 | `provider_options` | Options to configure the specified provider. | Map of String🠦String | None | No |
+| `refresh_interval` | Number of seconds between automated refreshing. | Integer | 60 | No |
 
 #### `DELETE` (`delete`)
 

--- a/pkg/backend/path_config.go
+++ b/pkg/backend/path_config.go
@@ -59,6 +59,11 @@ func (b *backend) configUpdateOperation(ctx context.Context, req *logical.Reques
 		return nil, err
 	}
 
+	refresh_interval := data.Get("tune_refresh_check_interval_seconds").(int)
+	if refresh_interval < 0 || refresh_interval > 90*24*60*60 {
+		return logical.ErrorResponse("invalid tune_refresh_check_interval_seconds"), nil
+	}
+
 	c := &persistence.ConfigEntry{
 		ClientID:        clientID.(string),
 		ClientSecret:    data.Get("client_secret").(string),
@@ -67,7 +72,7 @@ func (b *backend) configUpdateOperation(ctx context.Context, req *logical.Reques
 		ProviderVersion: p.Version(),
 		ProviderOptions: providerOptions,
 		Tuning: persistence.ConfigTuning{
-			RefreshCheckIntervalSeconds: data.Get("tune_refresh_check_interval_seconds").(int),
+			RefreshCheckIntervalSeconds: refresh_interval,
 		},
 	}
 	if err := b.data.Managers(req.Storage).Config().WriteConfig(ctx, c); err != nil {

--- a/pkg/backend/path_config.go
+++ b/pkg/backend/path_config.go
@@ -12,6 +12,10 @@ import (
 	"github.com/puppetlabs/vault-plugin-secrets-oauthapp/pkg/provider"
 )
 
+const (
+	DefaultRefreshCheckIntervalSeconds = 60
+)
+
 func (b *backend) configReadOperation(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	c, err := b.getCache(ctx, req.Storage)
 	if err != nil {
@@ -146,7 +150,7 @@ var configFields = map[string]*framework.FieldSchema{
 	"tune_refresh_check_interval_seconds": {
 		Type:        framework.TypeInt,
 		Description: "Specifies the interval in seconds between credential refresh, disabled if 0.",
-		Default:     60,
+		Default:     DefaultRefreshCheckIntervalSeconds,
 	},
 }
 

--- a/pkg/backend/path_config.go
+++ b/pkg/backend/path_config.go
@@ -27,6 +27,7 @@ func (b *backend) configReadOperation(ctx context.Context, req *logical.Request,
 			"provider":         c.Config.ProviderName,
 			"provider_version": c.Config.ProviderVersion,
 			"provider_options": c.Config.ProviderOptions,
+			"refresh_interval": c.Config.RefreshInterval,
 		},
 	}
 	return resp, nil
@@ -61,6 +62,7 @@ func (b *backend) configUpdateOperation(ctx context.Context, req *logical.Reques
 		ProviderName:    providerName.(string),
 		ProviderVersion: p.Version(),
 		ProviderOptions: providerOptions,
+		RefreshInterval: data.Get("refresh_interval").(int),
 	}
 	if err := b.data.Managers(req.Storage).Config().WriteConfig(ctx, c); err != nil {
 		return nil, err
@@ -138,6 +140,11 @@ var configFields = map[string]*framework.FieldSchema{
 	"provider_options": {
 		Type:        framework.TypeKVPairs,
 		Description: "Specifies any provider-specific options.",
+	},
+	"refresh_interval": {
+		Type:        framework.TypeInt,
+		Description: "Specifies the interval in seconds between credential refresh, disabled if 0.",
+		Default:     60,
 	},
 }
 

--- a/pkg/backend/path_config.go
+++ b/pkg/backend/path_config.go
@@ -22,12 +22,12 @@ func (b *backend) configReadOperation(ctx context.Context, req *logical.Request,
 
 	resp := &logical.Response{
 		Data: map[string]interface{}{
-			"client_id":        c.Config.ClientID,
-			"auth_url_params":  c.Config.AuthURLParams,
-			"provider":         c.Config.ProviderName,
-			"provider_version": c.Config.ProviderVersion,
-			"provider_options": c.Config.ProviderOptions,
-			"refresh_interval": c.Config.RefreshInterval,
+			"client_id":                           c.Config.ClientID,
+			"auth_url_params":                     c.Config.AuthURLParams,
+			"provider":                            c.Config.ProviderName,
+			"provider_version":                    c.Config.ProviderVersion,
+			"provider_options":                    c.Config.ProviderOptions,
+			"tune_refresh_check_interval_seconds": c.Config.Tuning.RefreshCheckIntervalSeconds,
 		},
 	}
 	return resp, nil
@@ -62,7 +62,9 @@ func (b *backend) configUpdateOperation(ctx context.Context, req *logical.Reques
 		ProviderName:    providerName.(string),
 		ProviderVersion: p.Version(),
 		ProviderOptions: providerOptions,
-		RefreshInterval: data.Get("refresh_interval").(int),
+		Tuning: persistence.ConfigTuning{
+			RefreshCheckIntervalSeconds: data.Get("tune_refresh_check_interval_seconds").(int),
+		},
 	}
 	if err := b.data.Managers(req.Storage).Config().WriteConfig(ctx, c); err != nil {
 		return nil, err
@@ -141,7 +143,7 @@ var configFields = map[string]*framework.FieldSchema{
 		Type:        framework.TypeKVPairs,
 		Description: "Specifies any provider-specific options.",
 	},
-	"refresh_interval": {
+	"tune_refresh_check_interval_seconds": {
 		Type:        framework.TypeInt,
 		Description: "Specifies the interval in seconds between credential refresh, disabled if 0.",
 		Default:     60,

--- a/pkg/backend/token_authcode.go
+++ b/pkg/backend/token_authcode.go
@@ -12,14 +12,11 @@ import (
 	"github.com/puppetlabs/vault-plugin-secrets-oauthapp/pkg/persistence"
 )
 
-const (
-	refreshInterval = time.Minute
-)
-
 type refreshProcess struct {
 	backend *backend
 	storage logical.Storage
 	keyer   persistence.AuthCodeKeyer
+	seconds int
 }
 
 var _ scheduler.Process = &refreshProcess{}
@@ -29,7 +26,7 @@ func (rp *refreshProcess) Description() string {
 }
 
 func (rp *refreshProcess) Run(ctx context.Context) error {
-	_, err := rp.backend.getRefreshCredToken(ctx, rp.storage, rp.keyer, refreshInterval+10*time.Second)
+	_, err := rp.backend.getRefreshCredToken(ctx, rp.storage, rp.keyer, time.Duration(rp.seconds)*time.Second)
 	return err
 }
 
@@ -41,29 +38,41 @@ type refreshDescriptor struct {
 var _ scheduler.Descriptor = &refreshDescriptor{}
 
 func (rd *refreshDescriptor) Run(ctx context.Context, pc chan<- scheduler.Process) error {
-	ticker := rd.backend.clock.NewTicker(refreshInterval)
-	defer ticker.Stop()
+	// start out checking once per minute
+	refreshInterval := 60
+	ticker := rd.backend.clock.NewTicker(time.Duration(refreshInterval)*time.Second)
 
 	for {
-		err := rd.backend.data.Managers(rd.storage).AuthCode().ForEachAuthCodeKey(ctx, func(keyer persistence.AuthCodeKeyer) {
-			proc := &refreshProcess{
-				backend: rd.backend,
-				storage: rd.storage,
-				keyer:   keyer,
+		c, err := rd.backend.getCache(ctx, rd.storage)
+		if err == nil && c != nil && c.Config.RefreshInterval != 0 {
+			if c.Config.RefreshInterval != refreshInterval {
+				refreshInterval = c.Config.RefreshInterval
+				ticker.Stop()
+				ticker = rd.backend.clock.NewTicker(time.Duration(refreshInterval)*time.Second)
 			}
+			err = rd.backend.data.Managers(rd.storage).AuthCode().ForEachAuthCodeKey(ctx, func(keyer persistence.AuthCodeKeyer) {
+				proc := &refreshProcess{
+					backend: rd.backend,
+					storage: rd.storage,
+					keyer:   keyer,
+					seconds: refreshInterval+10,
+				}
 
-			select {
-			case pc <- proc:
-			case <-ctx.Done():
+				select {
+				case pc <- proc:
+				case <-ctx.Done():
+				}
+			})
+			if err != nil {
+				ticker.Stop()
+				return err
 			}
-		})
-		if err != nil {
-			return err
 		}
 
 		select {
 		case <-ticker.C():
 		case <-ctx.Done():
+			ticker.Stop()
 			return nil
 		}
 	}

--- a/pkg/backend/token_authcode.go
+++ b/pkg/backend/token_authcode.go
@@ -44,9 +44,9 @@ func (rd *refreshDescriptor) Run(ctx context.Context, pc chan<- scheduler.Proces
 
 	for {
 		c, err := rd.backend.getCache(ctx, rd.storage)
-		if err == nil && c != nil && c.Config.RefreshInterval != 0 {
-			if c.Config.RefreshInterval != refreshInterval {
-				refreshInterval = c.Config.RefreshInterval
+		if err == nil && c != nil && c.Config.Tuning.RefreshCheckIntervalSeconds != 0 {
+			if c.Config.Tuning.RefreshCheckIntervalSeconds != refreshInterval {
+				refreshInterval = c.Config.Tuning.RefreshCheckIntervalSeconds
 				ticker.Stop()
 				ticker = rd.backend.clock.NewTicker(time.Duration(refreshInterval) * time.Second)
 			}

--- a/pkg/backend/token_authcode.go
+++ b/pkg/backend/token_authcode.go
@@ -40,7 +40,7 @@ var _ scheduler.Descriptor = &refreshDescriptor{}
 func (rd *refreshDescriptor) Run(ctx context.Context, pc chan<- scheduler.Process) error {
 	// start out checking once per minute
 	refreshInterval := 60
-	ticker := rd.backend.clock.NewTicker(time.Duration(refreshInterval)*time.Second)
+	ticker := rd.backend.clock.NewTicker(time.Duration(refreshInterval) * time.Second)
 
 	for {
 		c, err := rd.backend.getCache(ctx, rd.storage)
@@ -48,14 +48,14 @@ func (rd *refreshDescriptor) Run(ctx context.Context, pc chan<- scheduler.Proces
 			if c.Config.RefreshInterval != refreshInterval {
 				refreshInterval = c.Config.RefreshInterval
 				ticker.Stop()
-				ticker = rd.backend.clock.NewTicker(time.Duration(refreshInterval)*time.Second)
+				ticker = rd.backend.clock.NewTicker(time.Duration(refreshInterval) * time.Second)
 			}
 			err = rd.backend.data.Managers(rd.storage).AuthCode().ForEachAuthCodeKey(ctx, func(keyer persistence.AuthCodeKeyer) {
 				proc := &refreshProcess{
 					backend: rd.backend,
 					storage: rd.storage,
 					keyer:   keyer,
-					seconds: refreshInterval+10,
+					seconds: refreshInterval + 10,
 				}
 
 				select {

--- a/pkg/persistence/config.go
+++ b/pkg/persistence/config.go
@@ -11,6 +11,10 @@ const (
 	configKey = "config"
 )
 
+type ConfigTuning struct {
+	RefreshCheckIntervalSeconds int `json:"refresh_check_interval_seconds"`
+}
+
 type ConfigEntry struct {
 	ClientID        string            `json:"client_id"`
 	ClientSecret    string            `json:"client_secret"`
@@ -18,7 +22,7 @@ type ConfigEntry struct {
 	ProviderName    string            `json:"provider_name"`
 	ProviderVersion int               `json:"provider_version"`
 	ProviderOptions map[string]string `json:"provider_options"`
-	RefreshInterval int               `json:"refresh_interval"`
+	Tuning          ConfigTuning      `json:"tuning"`
 }
 
 type LockedConfigManager struct {

--- a/pkg/persistence/config.go
+++ b/pkg/persistence/config.go
@@ -18,6 +18,7 @@ type ConfigEntry struct {
 	ProviderName    string            `json:"provider_name"`
 	ProviderVersion int               `json:"provider_version"`
 	ProviderOptions map[string]string `json:"provider_options"`
+	RefreshInterval int               `json:"refresh_interval"`
 }
 
 type LockedConfigManager struct {


### PR DESCRIPTION
This adds a new config option "refresh_interval" which controls the number of seconds between periodically refreshing all the credentials, instead of making it always be one minute.  When set to zero, it disables periodic refreshing and makes it be only on demand.  I want it for disabling periodic refresh (because I don't think it scales, and because my refresh token are set to not expire for 30 days), but I thought other people might want to keep refreshing with a longer interval so I thought this was a good way to make it flexible.

I wanted to write some tests for this but I'm having trouble figuring out how TestPeriodicRefresh() works.  Maybe you could explain it.