### PR TITLE
feat: Add support for azure AD multitenant app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.1.0] - 2021-05-27
+
+### Changed
+
+* Add support for mutlitenant Azure AD apps that use client credentials flow. This is done by giving an ability to override provider options to change oauth2 URLs
+
 ## [2.0.0] - 2021-04-09
 
 ### Changed
@@ -160,7 +166,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Initial release of the plugin.
 
-[Unreleased]: https://github.com/puppetlabs/vault-plugin-secrets-oauthapp/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/puppetlabs/vault-plugin-secrets-oauthapp/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/puppetlabs/vault-plugin-secrets-oauthapp/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/puppetlabs/vault-plugin-secrets-oauthapp/compare/v1.10.1...v2.0.0
 [1.10.1]: https://github.com/puppetlabs/vault-plugin-secrets-oauthapp/compare/v1.10.0...v1.10.1
 [1.10.0]: https://github.com/puppetlabs/vault-plugin-secrets-oauthapp/compare/v1.9.0...v1.10.0

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ the `client_credentials` grant type.
 |------|-------------|------|---------|----------|
 | `token_url_params` | A map of additional query string parameters to provide to the token URL. If any keys in this map conflict with the parameters stored in the configuration, the configuration's parameters take precedence. | Map of String🠦String | None | No |
 | `scopes` | A list of explicit scopes to request. | List of String | None | No |
+| `provider_options` | A list of options to override for this flow. For example, to override tenant id for multitenant Azure AD app. | Map of String🠦String | None | None |
 
 #### `DELETE` (`delete`)
 

--- a/pkg/backend/token_clientcreds.go
+++ b/pkg/backend/token_clientcreds.go
@@ -36,6 +36,7 @@ func (b *backend) updateClientCredsToken(ctx context.Context, storage logical.St
 			ctx,
 			provider.WithURLParams(candidate.Config.TokenURLParams),
 			provider.WithScopes(candidate.Config.Scopes),
+			provider.WithProviderOptions(candidate.Config.ProviderOptions),
 		)
 		if err != nil {
 			return err

--- a/pkg/persistence/clientcreds.go
+++ b/pkg/persistence/clientcreds.go
@@ -24,8 +24,9 @@ type ClientCredsEntry struct {
 	Token *provider.Token `json:"token"`
 
 	Config struct {
-		Scopes         []string          `json:"scopes"`
-		TokenURLParams map[string]string `json:"token_url_params"`
+		Scopes          []string          `json:"scopes"`
+		TokenURLParams  map[string]string `json:"token_url_params"`
+		ProviderOptions map[string]string `json:"provider_options"`
 	} `json:"config"`
 }
 


### PR DESCRIPTION
Fixes the issue #50

I have made it possible to override endpoints before making any query. Azure AD provider always replaces `{{tenant}}` placeholder  to current tenant (it may be a global tenant or a specific one that was set via `config/self/:name` endpoint)