### PR TITLE
Add refresher tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   to set the `tenant` provider option on a per-credential basis if not
   explicitly specified in the provider configuration. If no tenant is provided,
   the tenant now defaults to allowing any Azure AD account.
+* The check interval for refreshing tokens is now configurable using the
+  `tune_refresh_check_interval_seconds` option. It can also be explicitly
+  disabled by setting the interval to 0.
 
 ### Changed
 

--- a/go.mod
+++ b/go.mod
@@ -5,14 +5,15 @@ go 1.14
 require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/golangci/golangci-lint v1.33.0
+	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-hclog v0.8.0
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/hashicorp/vault/api v1.0.4
 	github.com/hashicorp/vault/sdk v0.1.14-0.20190909201848-e0fbf9b652e2
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/puppetlabs/leg/errmap v0.1.0
-	github.com/puppetlabs/leg/scheduler v0.2.1
-	github.com/puppetlabs/leg/timeutil v0.4.0
+	github.com/puppetlabs/leg/scheduler v0.3.0
+	github.com/puppetlabs/leg/timeutil v0.4.1
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45

--- a/go.sum
+++ b/go.sum
@@ -289,6 +289,8 @@ github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyN
 github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
+github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -565,12 +567,10 @@ github.com/puppetlabs/leg/netutil v0.1.0/go.mod h1:ycY6MSkOndHh5azh5z66HH9IS8F04
 github.com/puppetlabs/leg/request v0.1.0 h1:4Eb9Ssk/Surjxyevh5i7PZjqarrCblpLWavPBLnxEio=
 github.com/puppetlabs/leg/request v0.1.0/go.mod h1:rLKkF3VdNg//iXBSTs+6Eir05BQR15rx3JNWTKiWzLI=
 github.com/puppetlabs/leg/scheduler v0.1.4/go.mod h1:kC6I8SA/nRt4VOu18qJ+HwBW+IxmXHI2lKicdfj3ItI=
-github.com/puppetlabs/leg/scheduler v0.2.1 h1:dJiUEDaw+O6nf7pjfHvbc/3ppRsGdDpfkDzpsWpv2GM=
-github.com/puppetlabs/leg/scheduler v0.2.1/go.mod h1:CWmohxDTfWafLxRhNQ+RIdREDdvus+XIdiEQrgFgdvo=
-github.com/puppetlabs/leg/timeutil v0.3.0 h1:7JUYWWW8bvSRU7EcEBVmkDv2gTb1uLE/F7hnEWljfQc=
-github.com/puppetlabs/leg/timeutil v0.3.0/go.mod h1:FHkZ9rYegF0STjS4az6hsjdvcBHcG+FB4CsY5mx1DfI=
-github.com/puppetlabs/leg/timeutil v0.4.0 h1:jPp+4t/zltrPkmcwSlfNsnxZnSgJPrtyw2hQuw9lxN8=
-github.com/puppetlabs/leg/timeutil v0.4.0/go.mod h1:NFYu1scx8y6qIzMWVzlUAxQ7Hp+2mqIeRm0QO8X29jk=
+github.com/puppetlabs/leg/scheduler v0.3.0 h1:buXLoomIDgclQ3NG5SKe+8jYzViIYX4ZVYfpPH5QVsg=
+github.com/puppetlabs/leg/scheduler v0.3.0/go.mod h1:9+nKYWy5GIWh2QsVQ/cKEI39yBn40qd3yydBu0K99Hk=
+github.com/puppetlabs/leg/timeutil v0.4.1 h1:d5+o49sHAqTFjzew1G/dAEc38EXNVC3LUtFH60/yEyM=
+github.com/puppetlabs/leg/timeutil v0.4.1/go.mod h1:NFYu1scx8y6qIzMWVzlUAxQ7Hp+2mqIeRm0QO8X29jk=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/quasilyte/go-ruleguard v0.2.0 h1:UOVMyH2EKkxIfzrULvA9n/tO+HtEhqD9mrLSWMr5FwU=
 github.com/quasilyte/go-ruleguard v0.2.0/go.mod h1:2RT/tf0Ce0UDj5y243iWKosQogJd8+1G3Rs2fxmlYnw=

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -23,6 +23,10 @@ type backend struct {
 	// It will be created by the backend lifecycle in the initialize method.
 	scheduler scheduler.StartedLifecycle
 
+	// restartRefresh causes the refresh descriptor to restart (when its
+	// configuration changes).
+	restartRefresh func()
+
 	// mut protects the cache value.
 	mut   sync.Mutex
 	cache *cache


### PR DESCRIPTION
This change also fixes a bunch of race conditions in the existing periodic refresh and device auth tests. It also improves the scheduled work by having it always run when the plugin starts or is reconfigured, so we're less likely to miss renewing access tokens.