### PR TITLE
Add support for custom expiry time in refresh token flow, for apps th…

### DIFF
--- a/pkg/backend/token_authcode.go
+++ b/pkg/backend/token_authcode.go
@@ -15,6 +15,7 @@ import (
 	"github.com/puppetlabs/leg/timeutil/pkg/clockctx"
 	"github.com/puppetlabs/leg/timeutil/pkg/retry"
 	"github.com/puppetlabs/vault-plugin-secrets-oauthapp/v3/pkg/persistence"
+	"github.com/puppetlabs/vault-plugin-secrets-oauthapp/v3/pkg/provider"
 )
 
 type refreshProcess struct {
@@ -121,7 +122,10 @@ func (b *backend) refreshCredToken(ctx context.Context, storage logical.Storage,
 			defer put()
 
 			// Refresh.
-			refreshed, err := ops.RefreshToken(clockctx.WithClock(ctx, b.clock), candidate.Token)
+			refreshed, err := ops.RefreshToken(clockctx.WithClock(ctx, b.clock),
+				candidate.Token,
+				provider.WithProviderOptions(candidate.ProviderOptions))
+
 			if err != nil {
 				msg := errmap.Wrap(errmark.MarkShort(err), "refresh failed").Error()
 				if errmark.MarkedUser(err) {

--- a/pkg/provider/basic.go
+++ b/pkg/provider/basic.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strconv"
 
 	gooidc "github.com/coreos/go-oidc"
 	"github.com/puppetlabs/leg/errmap/pkg/errmark"
@@ -16,6 +17,7 @@ import (
 	"golang.org/x/oauth2/gitlab"
 	"golang.org/x/oauth2/microsoft"
 	"golang.org/x/oauth2/slack"
+	"time"
 )
 
 func init() {
@@ -163,6 +165,11 @@ func (bo *basicOperations) RefreshToken(ctx context.Context, t *Token, opts ...R
 	}).Token()
 	if err != nil {
 		return nil, semerr.Map(err)
+	}
+
+	tokenExpiry, parseErr := strconv.ParseInt(o.ProviderOptions["token_expiry"], 10, 64)
+	if tok.Expiry.IsZero() && parseErr != nil && tokenExpiry > 0 {
+		tok.Expiry = time.Now().Add(time.Duration(tokenExpiry) * time.Second)
 	}
 
 	return &Token{


### PR DESCRIPTION
**Use Case**
For applications like Salesforce and Zendesk do not return the expires_in filed in the token response, for such applications access token was not refreshed. Added support to provide token_expiry field in the provider option and override token expiry with the value provided. This way, the user can define custom expiry time for apps where the expires_in field is absent.

**Example**

1. vault write oauth_custom/servers/salesforcetest provider=custom client_id={{cliend_id}} client_secret={{client_secret}} provider_options=token_url=https://{{instanceid}}.my.salesforce.com/services/oauth2/token

2. vault write oauth_custom/creds/salesforce server=salesforcetest grant_type=refresh_token refresh_token={{refresh_token}} provider_options=token_expiry=300

where token expiry is set to 300 seconds, 5 minutes.