### PR TITLE
For applications like Salesforce and Zendesk do not return the expire…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/puppetlabs/leg/scheduler v0.3.0
 	github.com/puppetlabs/leg/timeutil v0.4.2
 	github.com/puppetlabs/vault-plugin-secrets-oauthapp/v2 v2.2.0
+	github.com/spf13/cast v1.3.0
 	github.com/stretchr/testify v1.7.0
 	github.com/tencentcloud/tencentcloud-sdk-go v3.0.171+incompatible // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d

--- a/pkg/backend/token_authcode.go
+++ b/pkg/backend/token_authcode.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/puppetlabs/vault-plugin-secrets-oauthapp/v3/pkg/provider"
 	"math"
 	"time"
 
@@ -121,7 +122,10 @@ func (b *backend) refreshCredToken(ctx context.Context, storage logical.Storage,
 			defer put()
 
 			// Refresh.
-			refreshed, err := ops.RefreshToken(clockctx.WithClock(ctx, b.clock), candidate.Token)
+			refreshed, err := ops.RefreshToken(clockctx.WithClock(ctx, b.clock),
+				candidate.Token,
+				provider.WithProviderOptions(candidate.ProviderOptions))
+
 			if err != nil {
 				msg := errmap.Wrap(errmark.MarkShort(err), "refresh failed").Error()
 				if errmark.MarkedUser(err) {

--- a/pkg/provider/basic.go
+++ b/pkg/provider/basic.go
@@ -9,6 +9,7 @@ import (
 	"github.com/puppetlabs/leg/errmap/pkg/errmark"
 	"github.com/puppetlabs/vault-plugin-secrets-oauthapp/v3/pkg/oauth2ext/devicecode"
 	"github.com/puppetlabs/vault-plugin-secrets-oauthapp/v3/pkg/oauth2ext/semerr"
+	"github.com/spf13/cast"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/bitbucket"
 	"golang.org/x/oauth2/clientcredentials"
@@ -16,6 +17,7 @@ import (
 	"golang.org/x/oauth2/gitlab"
 	"golang.org/x/oauth2/microsoft"
 	"golang.org/x/oauth2/slack"
+	"time"
 )
 
 func init() {
@@ -163,6 +165,11 @@ func (bo *basicOperations) RefreshToken(ctx context.Context, t *Token, opts ...R
 	}).Token()
 	if err != nil {
 		return nil, semerr.Map(err)
+	}
+
+	tokenExpiry := cast.ToInt64(o.ProviderOptions["token_expiry"])
+	if tok.Expiry.IsZero() && tokenExpiry > 0 {
+		tok.Expiry = time.Now().Add(time.Duration(tokenExpiry) * time.Second)
 	}
 
 	return &Token{


### PR DESCRIPTION
…s_in filed in the token response, for such applications access token was not refreshed. Added support to provide token_expiry field in the provider option and override token expiry with the value provided. This way, the user can define custom expiry time for apps where the expires_in field is absent.